### PR TITLE
Fix tests namespaces

### DIFF
--- a/src/HelloWorld/Common/Routes/Routes.php
+++ b/src/HelloWorld/Common/Routes/Routes.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace HelloWorld\Common\Routes;
+
+
+use HelloWorld\Contracts\Common\Routes\Routes as RoutesCommonContract;
+
+
+class Routes implements RoutesCommonContract {
+    public function filterUri($uri) {
+        $uri = trim($uri);
+        $len = strlen($uri);
+        if($len > 0 && $uri[$len-1] === "/") {
+            $uri = substr($uri, 0, $len-1);
+            $len--;
+        }
+        if($len > 0 && $uri[0] === "/") {
+            $uri = substr($uri, 1);
+        }
+        return $uri;
+    }
+}

--- a/src/HelloWorld/Contracts/Common/Routes/Routes.php
+++ b/src/HelloWorld/Contracts/Common/Routes/Routes.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace HelloWorld\Contracts\Common\Routes;
+
+
+interface Routes {
+    public function filterUri($uri);
+}

--- a/src/HelloWorld/Statics/Routes.php
+++ b/src/HelloWorld/Statics/Routes.php
@@ -4,23 +4,18 @@ namespace HelloWorld\Statics;
 
 
 use HelloWorld\Contracts\Statics\Routes as RoutesContract;
-
+use HelloWorld\Common\Routes\Routes as RoutesCommon;
 
 class Routes implements RoutesContract {
     private $routesBase;
     private $routes;
+    private $routesCommon;
 
-    private function filterUri($uri) {
-        $uri = trim($uri);
-        $len = strlen($uri);
-        if($len > 0 && $uri[$len-1] === "/") {
-            $uri = substr($uri, 0, $len-1);
-            $len--;
+    private function routesCommon() {
+        if($this->routesCommon === null) {
+            $this->routesCommon = new RoutesCommon();
         }
-        if($len > 0 && $uri[0] === "/") {
-            $uri = substr($uri, 1);
-        }
-        return $uri;
+        return $this->routesCommon;
     }
 
     public function __construct($routesBase) {
@@ -42,7 +37,7 @@ class Routes implements RoutesContract {
                     $this->routes[$method] = [];
                 }
                 foreach($list as $uri => $details) {
-                    $uri = $prefix . $this->filterUri($uri);
+                    $uri = $prefix . $this->routesCommon()->filterUri($uri);
                     $this->routes[$method][$uri] = $details;
                 }
             }

--- a/tests/HelloWorld/App/AppTest.php
+++ b/tests/HelloWorld/App/AppTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Tests\HelloWorld\App;
+
+
 use PHPUnit\Framework\TestCase;
 use HelloWorld\App\App;
 use HelloWorld\Contracts\App\App as AppContract;

--- a/tests/HelloWorld/App/GlobalsTest.php
+++ b/tests/HelloWorld/App/GlobalsTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Tests\HelloWorld\App;
+
+
 use PHPUnit\Framework\TestCase;
 use HelloWorld\Contracts\App\Globals as GlobalsContract;
 use HelloWorld\App\Globals;

--- a/tests/HelloWorld/Common/Routes/RoutesTest.php
+++ b/tests/HelloWorld/Common/Routes/RoutesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\HelloWorld\Common\Routes;
+
+
+use PHPUnit\Framework\TestCase;
+use HelloWorld\Common\Routes\Routes as RoutesCommon;
+
+
+class RoutesTest extends TestCase {
+    public function testContract() {
+        $routesCommon = new RoutesCommon();
+        $this->assertTrue($routesCommon instanceof RoutesCommon);
+    }
+    public function testFilterUri() {
+        $uri = " /api/users/{id}/ ";
+        $expected = "api/users/{id}";
+        $routesCommon = new RoutesCommon();
+        $this->assertEquals($expected, $routesCommon->filterUri($uri));
+    }
+}

--- a/tests/HelloWorld/Statics/RoutesTest.php
+++ b/tests/HelloWorld/Statics/RoutesTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Tests\HelloWorld\Statics;
+
+
 use PHPUnit\Framework\TestCase;
 use HelloWorld\Contracts\Statics\Routes as RoutesContract;
 use HelloWorld\Statics\Routes;


### PR DESCRIPTION
1. fixed tests namespaces
2. added common/routes/routes to hold common utilities such as filterUri
3. added modified statics/routes file: modified due to change of filterUri transfer in common/routes/routes